### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "spatial-rx",
+  "install": "curl -LsSf https://astral.sh/uv/install.sh | sh && \"$HOME/.local/bin/uv\" sync --extra demo --group dev",
+  "terminals": [
+    {
+      "name": "marimo-landmarks",
+      "command": "export PATH=\"$HOME/.local/bin:$PATH\" && uv run marimo edit demos/landmarks.py --headless --no-sandbox --no-token --host 0.0.0.0 -p 2718"
+    }
+  ],
+  "ports": [2718]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment (`.cursor/environment.json`) for `spatial-rx` so future agents boot with dependencies installed and the marimo widget demo ready to run.

## What it does

- **install**: installs `uv` (standalone installer) and runs `uv sync --extra demo --group dev`, matching the from-source setup in `README.md` and the CI workflow.
- **terminals**: launches `marimo edit demos/landmarks.py` (headless, no sandbox) on port `2718` as the visible dev server.
- **ports**: exposes `2718`.

## Validation

| Check | Result |
| --- | --- |
| `uv run pytest` | 6 passed |
| `uv build` | sdist + wheel built |
| Install idempotence | Passed (rerun re-resolves, no changes) |
| LandmarksWidget demo (marimo) | Map renders; recolor, use-case cards, and draw-to-measure all work end-to-end |
| Draft environment build | SUCCEEDED (`uv` + `uv sync` install, exit 0) |
| Fresh Cloud Agent from build | uv 0.12.7, imports ok, `.venv` present, 6 tests pass, `uv build` ok, marimo HTTP 200 |

The end-to-end demo (recolor cells, pick a use-case card, draw a spline landmark, and read the resulting measurement chart) was recorded from the running app.

[spatial_rx_landmarks_widget_demo.mp4](https://cursor.com/agents/bc-9b9e59c5-1646-4f57-8077-158f0e71b2d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspatial_rx_landmarks_widget_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b9e59c5-1646-4f57-8077-158f0e71b2d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b9e59c5-1646-4f57-8077-158f0e71b2d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

