### PR TITLE
fix(landmarks): theme-aware color swatches and legends

### DIFF
--- a/frontend/src/widgets/landmarks/chrome/genes-legend.tsx
+++ b/frontend/src/widgets/landmarks/chrome/genes-legend.tsx
@@ -40,7 +40,7 @@ function GenesHorizontalBar({
 }) {
   const gradient =
     colors.length === 1
-      ? `linear-gradient(to right, #0a0a0a, ${colors[0]})`
+      ? `linear-gradient(to right, var(--background), ${colors[0]})`
       : `linear-gradient(to right, ${colors[0]}, ${blendHex(colors[0], colors[1])}, ${colors[1]})`;
 
   return (
@@ -51,7 +51,7 @@ function GenesHorizontalBar({
             key={`${label}-${i}`}
             className="inline-flex min-w-0 items-center gap-1 truncate text-foreground"
           >
-            <ColorSwatch color={colors[i] || "#94a3b8"} />
+            <ColorSwatch color={colors[i]} />
             <span className="truncate">{label}</span>
           </span>
         ))}
@@ -276,7 +276,7 @@ export function GenesCombobox({ lm }: { lm: LandmarksModel }) {
                     color={
                       selIdx >= 0
                         ? GENE_COLORS[selIdx % GENE_COLORS.length]
-                        : "#94a3b8"
+                        : undefined
                     }
                   />
                   {name}

--- a/frontend/src/widgets/landmarks/chrome/layers-panel.tsx
+++ b/frontend/src/widgets/landmarks/chrome/layers-panel.tsx
@@ -128,7 +128,7 @@ export function LayersPanel({
                             color={
                               (col.palette || [])[
                                 i % Math.max((col.palette || []).length, 1)
-                              ] || "#888888"
+                              ]
                             }
                             label={label}
                             onSelect={() => lm.selectType(col, i)}

--- a/frontend/src/widgets/landmarks/chrome/primitives.tsx
+++ b/frontend/src/widgets/landmarks/chrome/primitives.tsx
@@ -71,7 +71,7 @@ export function ColorSwatch({
   fillOpacity = 0.25,
   className,
 }: {
-  color: string;
+  color?: string;
   variant?: SwatchVariant;
   fillOpacity?: number;
   className?: string;
@@ -82,12 +82,17 @@ export function ColorSwatch({
       <span
         className={cn(
           "landmarks-layer-swatch landmarks-layer-swatch--landmark inline-block shrink-0 rounded-full",
+          !color && "border-border",
           className,
         )}
-        style={{
-          borderColor: color,
-          backgroundColor: `color-mix(in srgb, ${color} ${pct}%, transparent)`,
-        }}
+        style={
+          color
+            ? {
+                borderColor: color,
+                backgroundColor: `color-mix(in srgb, ${color} ${pct}%, transparent)`,
+              }
+            : undefined
+        }
         aria-hidden
       />
     );
@@ -97,9 +102,10 @@ export function ColorSwatch({
       <span
         className={cn(
           "landmarks-layer-swatch landmarks-layer-swatch--selection inline-block shrink-0 rounded-full",
+          !color && "border-border",
           className,
         )}
-        style={{ borderColor: color }}
+        style={color ? { borderColor: color } : undefined}
         aria-hidden
       />
     );
@@ -108,9 +114,10 @@ export function ColorSwatch({
     <span
       className={cn(
         "landmarks-layer-swatch inline-block shrink-0 rounded-full ring-1 ring-border",
+        !color && "bg-muted-foreground/40",
         className,
       )}
-      style={{ backgroundColor: color }}
+      style={color ? { backgroundColor: color } : undefined}
       aria-hidden
     />
   );
@@ -261,14 +268,12 @@ export function LayerRow({
         }
       }}
     >
-      {color ? (
-        <ColorSwatch
-          color={color}
-          variant={swatchVariant}
-          fillOpacity={swatchFillOpacity}
-          className="landmarks-layer-swatch"
-        />
-      ) : null}
+      <ColorSwatch
+        color={color}
+        variant={swatchVariant}
+        fillOpacity={swatchFillOpacity}
+        className="landmarks-layer-swatch"
+      />
       <div className="landmarks-layer-label">
         {editing && onRename ? (
           <Input


### PR DESCRIPTION
## Summary

Make UI chrome follow theme tokens while data-encoding colors stay fixed. Every change sorts a color into the correct bucket.

## Changes

| File | What |
|---|---|
| `chrome/primitives.tsx` | `ColorSwatch.color` now optional; each variant gets a theme-aware neutral fallback (`border-border` for landmark/selection, `bg-muted-foreground/40` for solid) |
| `chrome/primitives.tsx` | `LayerRow` always renders `<ColorSwatch>` — no more conditional gate, rows stay aligned |
| `chrome/layers-panel.tsx` | Category color drops `\|\| "#888888"` — undefined falls through to swatch neutral |
| `chrome/genes-legend.tsx` | GenesCombobox unselected item drops `#94a3b8` — undefined falls through to swatch neutral |
| `chrome/genes-legend.tsx` | `GenesHorizontalBar` label swatch drops `\|\| "#94a3b8"` |
| `chrome/genes-legend.tsx` | Single-gene gradient low-end: `#0a0a0a` → `var(--background)` — canvas bg flips with theme (`landmarks--dark` → `#1e1e1e`, else `#ffffff`) |

## Decisions

- **Gradient low-end:** Canvas background is theme-aware (`resolvePlotBackground` checks `landmarks--dark`), so `var(--background)` tracks the surface correctly.
- **Neighbors legend dots:** Kept as-is (`bg-foreground` / `bg-muted-foreground/40`). These are UI legend tokens representing the visual treatment (full vs dimmed opacity), not data colors. They correctly flip with theme.

## Verification

- [x] `tsc --noEmit` passes
- [x] `npm run build` passes
